### PR TITLE
[feat] 알람 기능 구현

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <!-- alarmManager 권한 -->
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"/>
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+
+
     <application
         android:name=".App"
         android:allowBackup="false"
@@ -14,6 +19,17 @@
         android:theme="@style/Theme.SmartCareApp"
         android:usesCleartextTraffic="true"
         tools:targetApi="31">
+
+        <receiver
+            android:name=".alarm.AlarmReceiver"
+            android:exported="false"
+            android:enabled="true">
+            <intent-filter>
+                <action android:name="com.dgu.smartcareapp.ALARM_ACTION"/>
+            </intent-filter>
+        </receiver>
+
+
         <activity
             android:name=".presentation.main.MainActivity"
             android:exported="true"
@@ -21,16 +37,14 @@
             android:windowSoftInputMode="adjustPan">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
 
         <activity
             android:name=".presentation.CreationTodo.CreationTodoActivity"
-            android:exported="false"
+            android:exported="true"
             android:theme="@style/Theme.SmartCareApp"
-            android:windowSoftInputMode="adjustPan"/>
+            android:windowSoftInputMode="adjustPan" />
     </application>
-
 </manifest>

--- a/app/src/main/java/com/dgu/smartcareapp/alarm/AlarmManager.kt
+++ b/app/src/main/java/com/dgu/smartcareapp/alarm/AlarmManager.kt
@@ -1,0 +1,23 @@
+package com.dgu.smartcareapp.alarm
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
+
+/**
+ * todo naming 고민
+ * 알람이 울릴 때 전역적으로 방출하기 위해 사용하는 flow
+ * 전역적으로 해당 flow 하나만 존재하게 하기 위해서 object로 구현
+ */
+object AlarmManager {
+    private val _alarm = MutableSharedFlow<String?>(1)
+    val alarm = _alarm.asSharedFlow()
+
+    fun emitAlarm(toDoTitle: String?) {
+        CoroutineScope(Dispatchers.Default).launch {
+            _alarm.emit(toDoTitle)
+        }
+    }
+}

--- a/app/src/main/java/com/dgu/smartcareapp/alarm/AlarmReceiver.kt
+++ b/app/src/main/java/com/dgu/smartcareapp/alarm/AlarmReceiver.kt
@@ -1,0 +1,22 @@
+package com.dgu.smartcareapp.alarm
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+
+/**
+ * 알람 관련 브로드 캐스트 리시버
+ */
+class AlarmReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context?, intent: Intent?) {
+        val toDoTitle = intent?.getStringExtra(TODO_TITLE)
+
+        Log.d("dana", toDoTitle.toString())
+        AlarmManager.emitAlarm(toDoTitle)
+    }
+
+    companion object {
+        const val TODO_TITLE = "todoTitle"
+    }
+}

--- a/app/src/main/java/com/dgu/smartcareapp/alarm/AlarmUtils.kt
+++ b/app/src/main/java/com/dgu/smartcareapp/alarm/AlarmUtils.kt
@@ -15,7 +15,7 @@ import java.util.Calendar
 class AlarmUtils(private val context: Context) {
     private val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
 
-    fun setAlarm(hour: Int, minute: Int, toDoTitle: String) {
+    fun setAlarm(hour: Int, minute: Int, toDoTitle: String, requestCode: Int) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             if (!alarmManager.canScheduleExactAlarms()) {
                 val intent = Intent(ACTION_REQUEST_SCHEDULE_EXACT_ALARM)
@@ -32,7 +32,7 @@ class AlarmUtils(private val context: Context) {
 
         val alarmIntent = PendingIntent.getBroadcast(
             context,
-            0,
+            requestCode,
             intent,
             PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
         )

--- a/app/src/main/java/com/dgu/smartcareapp/alarm/AlarmUtils.kt
+++ b/app/src/main/java/com/dgu/smartcareapp/alarm/AlarmUtils.kt
@@ -1,0 +1,63 @@
+package com.dgu.smartcareapp.alarm
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.provider.Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM
+import android.util.Log
+import java.util.Calendar
+
+/**
+ * 알람 관련 utils
+ */
+class AlarmUtils(private val context: Context) {
+    private val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+
+    fun setAlarm(hour: Int, minute: Int, toDoTitle: String) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            if (!alarmManager.canScheduleExactAlarms()) {
+                val intent = Intent(ACTION_REQUEST_SCHEDULE_EXACT_ALARM)
+                context.startActivity(intent)
+                return
+            }
+        }
+
+        val intent = Intent(context, AlarmReceiver::class.java)
+            .apply {
+                action = "com.dgu.smartcareapp.ALARM_ACTION"
+                putExtra(TODO_TITLE, toDoTitle)
+            }
+
+        val alarmIntent = PendingIntent.getBroadcast(
+            context,
+            0,
+            intent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
+
+        val calendar = Calendar.getInstance().apply {
+            set(Calendar.HOUR_OF_DAY, hour)
+            set(Calendar.MINUTE, minute)
+            set(Calendar.SECOND, 0)
+            set(Calendar.MILLISECOND, 0)
+
+            if (before(Calendar.getInstance())) {
+                add(Calendar.DATE, 1)
+            }
+        }
+
+        alarmManager.setExactAndAllowWhileIdle(
+            AlarmManager.RTC_WAKEUP,
+            calendar.timeInMillis,
+            alarmIntent
+        )
+
+        Log.d("dana", "알람이 설정되었습니다: ${calendar.time}")
+    }
+
+    companion object {
+        const val TODO_TITLE = "todoTitle"
+    }
+}

--- a/app/src/main/java/com/dgu/smartcareapp/component/AlarmDialog.kt
+++ b/app/src/main/java/com/dgu/smartcareapp/component/AlarmDialog.kt
@@ -1,0 +1,67 @@
+package com.dgu.smartcareapp.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.dgu.smartcareapp.ui.theme.SmartCareAppTheme
+import com.dgu.smartcareapp.ui.theme.mainOrange
+import com.dgu.smartcareapp.ui.theme.semiBold14
+import com.dgu.smartcareapp.ui.theme.semiBold16
+
+@Composable
+fun AlarmDialog(
+    toDoTitle: String = "",
+    onConfirm: () -> Unit = {}
+) {
+    Dialog(onDismissRequest = {}) {
+        Column(
+            modifier = Modifier
+                .clip(shape = RoundedCornerShape(18.dp))
+                .background(Color.White)
+                .padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+
+            Text(
+                text = toDoTitle,
+                style = semiBold16()
+            )
+
+            Box(
+                modifier = Modifier.padding(top = 16.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    modifier = Modifier
+                        .padding(6.dp)
+                        .clickable { onConfirm.invoke() },
+                    text = "완료했어요",
+                    style = semiBold14(),
+                    color = mainOrange
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun AlarmDialogPreview() {
+    SmartCareAppTheme {
+        AlarmDialog(
+            toDoTitle = "한자두자세자네자다섯자여섯"
+        )
+    }
+}

--- a/app/src/main/java/com/dgu/smartcareapp/presentation/CreationTodo/CreationTodoActivity.kt
+++ b/app/src/main/java/com/dgu/smartcareapp/presentation/CreationTodo/CreationTodoActivity.kt
@@ -88,7 +88,12 @@ class CreationTodoActivity : ComponentActivity() {
                             // todo 할일 추가 (로컬에서)
                             // todo 로컬에서 추가 onSuccess 한 후에 알람 등록되는 거로 수정
                             val (hour, minute) = time.split(":").map { it.toInt() }
-                            alarmUtils.setAlarm(hour, minute, toDoTitle)
+
+                            // request code의 유일성을 위해 랜덤함수를 사용 -> 차후에 리팩토링
+                            val randomRequestCode = (1..100000) // 1~100000 범위에서 알람코드 랜덤으로 생성
+                            val alarmCode = randomRequestCode.random()
+
+                            alarmUtils.setAlarm(hour, minute, toDoTitle, alarmCode)
                         },
                         onConfirmToDoTime = { hour, minute ->
                             viewModel.confirmTodoTime(hour, minute)

--- a/app/src/main/java/com/dgu/smartcareapp/presentation/CreationTodo/CreationTodoActivity.kt
+++ b/app/src/main/java/com/dgu/smartcareapp/presentation/CreationTodo/CreationTodoActivity.kt
@@ -1,37 +1,103 @@
 package com.dgu.smartcareapp.presentation.CreationTodo
 
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.lifecycleScope
+import com.dgu.smartcareapp.alarm.AlarmManager
+import com.dgu.smartcareapp.alarm.AlarmReceiver
+import com.dgu.smartcareapp.alarm.AlarmUtils
+import com.dgu.smartcareapp.component.AlarmDialog
 import com.dgu.smartcareapp.ui.theme.SmartCareAppTheme
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 
+@AndroidEntryPoint
 class CreationTodoActivity : ComponentActivity() {
     val viewModel: CreationViewModel by viewModels()
+    lateinit var alarmUtils: AlarmUtils
+    lateinit var alarmReceiver: AlarmReceiver
+
+    // todo rememberSaveble로 수정
+    val isShow = mutableStateOf(false)
+    val toDoTitle: MutableState<String?> = mutableStateOf(null)
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        alarmUtils = AlarmUtils(this)
+        alarmReceiver = AlarmReceiver()
+
         setContent {
             val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+            val lifecycleOwner = LocalLifecycleOwner.current
+
+
+            // 이 부분 확인해보기
+            DisposableEffect(lifecycleOwner) {
+                val observer = LifecycleEventObserver { _, event ->
+                    if (event == Lifecycle.Event.ON_RESUME) {
+                        lifecycleScope.launch {
+                            // 가장 최근 알람을 받아 옴
+                            AlarmManager.alarm.collectLatest {
+                                Log.d("dana", "알람왔다!")
+                                isShow.value = true
+                                toDoTitle.value = it
+                            }
+                        }
+                    }
+                }
+                lifecycleOwner.lifecycle.addObserver(observer)
+                onDispose {
+                    lifecycleOwner.lifecycle.removeObserver(observer)
+                }
+            }
 
             SmartCareAppTheme {
-                CreationTodoScreen(
-                    uiState = uiState,
-                    onValueChanged = {
-                        viewModel.onTodoTextValueChanged(it)
-                    },
-                    onButtonClick = {
-                        // todo 할일 추가
-                    },
-                    onConfirmToDoTime = { hour, minute ->
-                        viewModel.confirmTodoTime(hour, minute)
-                    },
-                    onNavigationIconClick = {
-                        // todo 뒤로가기
+                Box(modifier = Modifier.fillMaxSize()) {
+
+                    if (isShow.value) {
+                        toDoTitle.value?.let {
+                            AlarmDialog(
+                                toDoTitle = it,
+                                onConfirm = { isShow.value = false }
+                            )
+                        }
                     }
-                )
+
+                    CreationTodoScreen(
+                        uiState = uiState,
+                        onValueChanged = {
+                            viewModel.onTodoTextValueChanged(it)
+                        },
+                        onButtonClick = { time, toDoTitle ->
+                            // todo 할일 추가 (로컬에서)
+                            // todo 로컬에서 추가 onSuccess 한 후에 알람 등록되는 거로 수정
+                            val (hour, minute) = time.split(":").map { it.toInt() }
+                            alarmUtils.setAlarm(hour, minute, toDoTitle)
+                        },
+                        onConfirmToDoTime = { hour, minute ->
+                            viewModel.confirmTodoTime(hour, minute)
+                        },
+                        onNavigationIconClick = {
+                            // todo 뒤로가기
+                        }
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/dgu/smartcareapp/presentation/CreationTodo/CreationTodoScreen.kt
+++ b/app/src/main/java/com/dgu/smartcareapp/presentation/CreationTodo/CreationTodoScreen.kt
@@ -47,7 +47,7 @@ fun CreationTodoScreen(
     uiState: UiState,
     onValueChanged: (String) -> Unit = {},
     onConfirmToDoTime: (Int, Int) -> Unit = { _, _ -> },
-    onButtonClick: () -> Unit = {},
+    onButtonClick: (time: String, toDoTitle: String) -> Unit = { _, _ -> },
     onNavigationIconClick: () -> Unit = {},
 ) {
     val toDoTextEnabled by remember(key1 = uiState.toDoTitle) {
@@ -129,7 +129,12 @@ fun CreationTodoScreen(
                     .align(Alignment.BottomCenter)
                     .padding(16.dp),
                 enabled = uiState.toDoTitle.isNotBlank() && uiState.selectedTimeText.isNotBlank(),
-                onButtonClick = onButtonClick
+                onButtonClick = {
+                    onButtonClick.invoke(
+                        uiState.selectedTimeText,
+                        uiState.toDoTitle
+                    )
+                }
             )
         }
     }


### PR DESCRIPTION
## 📑 Work Description
- 알람 매니저와 브로드 캐스트 리시버를 활용해 로컬 알람 기능을 구현했습니다.

- [x] 알람 제시간에 잘 울림
- [x] 여러개 등록해도 울림
- [ ] 기기 재부팅 시 알람 재설정 -> 리팩토링 예정
- [ ] 알람 끄기 전까지는 최소 3분동안은 화면에 노출 -> 구현 여부 미확정, 나머지가 빨리 끝나면 구현하겠습니다.

## 🛠️ Issue
- closed #

## 📷 Screenshot


## 💬 To Reviewers
@l2zh 네비게이션 관련해서 로직을 제가 작성하지 않아서 시간이 되신다면 부탁드립니다 ㅜㅜ !
@emjayMJkim toDo주석, 이전 mr에 코리 달린거 보고 조금 수정부탁드려요

+)
모든 화면에서 전역적으로 해당 다이얼로그 노출하기 위해서 flow를 방출해서 수집하는 방식으로 진행할 예정이나,
네비게이션 로직을 잘 이해하지 못해서, 우선은 제가 구현해놓은 CreationActivity에 알람이 노출되는 로직을 작성해놓은 상태입니다